### PR TITLE
chore(ci): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,3 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(ci): "
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
# Initialize [GitHub Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates).

Configures Dependabot to create regular update PRs.
